### PR TITLE
Added API tests for SimpleSink and SimpleSource

### DIFF
--- a/libgflow/gflow-simple-sink.vala
+++ b/libgflow/gflow-simple-sink.vala
@@ -25,19 +25,19 @@ namespace GFlow {
      */
     public class SimpleSink : Object, Dock, Sink {
         // Dock interface
-        private GLib.Value _val;
-        private GLib.Value _initial;
-        private bool _valid = false;
+        protected GLib.Value? _val = null;
+        protected GLib.Value? _initial = null;
+        protected bool _valid = false;
 
         public string? name { get; set; }
-        public bool highlight { get; set; }
+        public bool highlight { get; set; default = false; }
         public bool active {get; set; default=false;}
         public weak Node? node { get; set; }
         public GLib.Value? val { get { return _val; } set { change_value (value); } }
         public GLib.Value? initial { get { return _initial; } }
         public bool valid { get { return _valid; } }
         // Sink Interface
-        private weak Source? _source;
+        protected weak Source? _source;
         public weak Source? source {
             get{
                 return this._source;
@@ -45,8 +45,8 @@ namespace GFlow {
             set { change_source (value); }
         }
 
-        public SimpleSink(GLib.Value initial) {
-            base(initial);
+        public SimpleSink (GLib.Value? initial) {
+          _val = _initial = initial;
         }
 
         /**

--- a/libgflow/gflow-simple-source.vala
+++ b/libgflow/gflow-simple-source.vala
@@ -25,9 +25,9 @@ namespace GFlow {
      */
     public class SimpleSource : Object, Dock, Source {
         // Dock interface
-        private GLib.Value _val;
-        private GLib.Value _initial;
-        private bool _valid = false;
+        protected GLib.Value? _val;
+        protected GLib.Value? _initial;
+        protected bool _valid = false;
 
         public string? name { get; set; }
         public bool highlight { get; set; }
@@ -39,6 +39,10 @@ namespace GFlow {
             _val = value;
             changed ();
           }
+        }
+        public SimpleSource (GLib.Value initial) {
+          _initial = initial;
+          val = _initial;
         }
         public GLib.Value? initial { get { return _initial; } }
         public bool valid { get { return _valid; } }

--- a/test/gflow-sink-test.vala
+++ b/test/gflow-sink-test.vala
@@ -24,6 +24,20 @@ public class GFlowTest.SinkTest
   {
     Test.add_func ("/gflow/sink", 
     () => {
+      Value initial = Value(typeof(int));
+      initial.set_int (1);
+      var s = new GFlow.SimpleSink (initial);
+      assert (s.initial != null);
+      assert (s.val != null);
+      assert (s.val.holds (typeof(int)));
+      assert (s.val.get_int () == 1);
+      assert (s.val.type () == typeof (int));
+      assert (!s.valid);
+      assert (!s.highlight);
+      assert (!s.active);
+      assert (s.node == null);
+      assert (s.source == null);
+      assert (!s.is_connected ());
     });
   }
 }

--- a/test/gflow-source-test.vala
+++ b/test/gflow-source-test.vala
@@ -18,12 +18,33 @@
  */
 using GFlow;
 
+public class GFlowTest.Source : GFlow.SimpleSource
+{
+  public void update ()
+  {
+    if (_val.get_boolean ()) _val.set_boolean (false);
+    else _val.set_boolean (true);
+  }
+  public Source () {
+    Value v = false;
+    base (v);
+  }
+}
+
 public class GFlowTest.SourceTest
 {
   public static void add_tests ()
   {
     Test.add_func ("/gflow/source", 
     () => {
+      var src = new GFlowTest.Source ();
+      assert (src.initial != null);
+      assert (src.val != null);
+      assert (src.val.holds (typeof (bool)));
+      assert (!src.val.get_boolean ());
+      src.update ();
+      assert (src.val.get_boolean ());
+      assert (!src.is_connected ());
     });
   }
 }


### PR DESCRIPTION
We need to finish GFlow with its Unit Tests before to wire it up to GtkFlow.

I've made a merge of my local repository to your gflow_wiring and found lot of issues and misconceptions (take me this with the better intention) and make it hard to me to work on your branch at the moment, even that I think we need to work on.

I would like to continue on master for GFlow with no glue with GtkFlow at all, as it is today. This will help us to have a solid well tested library with possible some implementations and a good API to use for GtkFlow.

Even the last, please consider the following:

GtkFlow widgets can't (for desing) have more than one parent. Then they should descent from Gtk+ objects as they do today. In order to gain GFlow access, a property of the object to use should be added. Then for GtkFlow.Node you should have a:

public GFlow.Node node { get; set; }

of course you need to add custom code on get and set, to save in a private variable _node this object and trigger re-draw, layout or any think this is done today. This mean that, may you need a default state of the widget if no GFlow.Node is set or create a new GFlow.SimpleNode on construct to draw something.
