### PR TITLE
Simplify interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,16 @@ GtkFlow-*.gir
 libgtkflow/.libs/
 libgtkflow/gtkflow-0.2.vapi
 ChangeLog
+libgflow/.deps/
+libgflow/.libs/
+libgflow/GFlow-0.2.gir
+libgflow/GFlow-0.2.typelib
+libgflow/gflow-0.2.pc
+libgflow/gflow-0.2.vapi
+libgflow/gflow.h
+libgflow/namespace-info.vala
+test/.deps/
+test/tests-config.vala
 
 # Python cache folders
 

--- a/libgflow/gflow-dock.vala
+++ b/libgflow/gflow-dock.vala
@@ -96,6 +96,15 @@ namespace GFlow {
 
         public abstract bool is_connected_to (Dock dock);
 
+        /**
+         * Disconnect this {@link Dock} from other {@link Dock}
+         */
+        public abstract void connect (Dock dock) throws GLib.Error;
+        /**
+         * Connect this {@link Dock} to other {@link Dock}
+         */
+        public abstract void disconnect (Dock dock) throws GLib.Error;
+
         // FIXME: This could be changed to get_stypestring
         public virtual string determine_typestring () {
             GLib.TypeQuery tq;

--- a/libgflow/gflow-simple-source.vala
+++ b/libgflow/gflow-simple-source.vala
@@ -49,6 +49,33 @@ namespace GFlow {
         // Source interface
         private List<Sink> _sinks = new List<Sink> ();
         public List<Sink> sinks { get { return _sinks; } }
+
+        protected void add_sink (Sink s) throws Error
+        {
+            if (this.val.type() != s.val.type()) {
+                throw new NodeError.INCOMPATIBLE_SINKTYPE(
+                    "Can't connect. Sink has type %s while Source has type %s".printf(
+                        s.val.type().name(), this.val.type().name()
+                    )
+                );
+            }
+            if (this.sinks.index(s) == -1)
+                this.sinks.append(s);
+            if (!((Dock) s).is_connected_to(this))
+                s.connect (this);
+            if (this.valid) {
+                s.val = this.val;
+            }
+            connected ((Dock) s);
+        }
+        protected void remove_sink (Sink s) throws GLib.Error
+        {
+            if (this.sinks.index(s) != -1)
+                this.sinks.remove(s);
+            if (s.is_connected_to(this))
+                s.disconnect (this);
+            this.disconnected(s);
+        }
         // FIXME This should not be set by users is a mutter of test to know if source should work
         public new void set_valid() {
             this._valid = true;
@@ -64,10 +91,42 @@ namespace GFlow {
         /**
          * Returns true if this Source is connected to one or more Sinks
          */
-        public bool is_connected() {
-            return this.sinks.length() > 0;
+        public bool is_connected () {
+            return this.sinks.length () > 0;
         }
         // FIXME: Added to implement the one on Dock - Review
         public void invalidate () { _valid = false; }
+        // FIXME Added to simplify Source interface
+        public new void disconnect (Dock dock) throws GLib.Error
+        {
+          if (!dock.is_connected_to (this)) return;
+          if (dock is Sink) {
+            remove_sink ((Sink) dock);
+            if (sinks.length () == 0) disconnected (dock);
+          }
+        }
+        public new void connect (Dock dock) throws GLib.Error
+        {
+          if (dock.is_connected_to (this)) return;
+          if (dock is Sink) {
+            add_sink ((Sink) dock);
+            connected (dock);
+          }
+        }
+        /**
+         * FIXME This could be removed and make connected Dock to lisen updated () signal
+         */
+        public void set_value (GLib.Value v) throws GLib.Error
+        {
+            if (this.val.type() != v.type())
+                throw new NodeError.INCOMPATIBLE_VALUE(
+                    "Cannot set a %s value to this %s Source".printf(
+                        v.type().name(),this.val.type().name())
+                );
+            this.val = v;
+            foreach (Sink s in this.sinks)
+                s.val = v;
+            updated ();
+        }
     }
 }

--- a/libgflow/gflow-sink.vala
+++ b/libgflow/gflow-sink.vala
@@ -26,63 +26,10 @@ namespace GFlow {
      */
     public interface Sink : Object, Dock {
         /**
-         * The Source that this Sink draws its data from.
+         * The Source that this Sink gets its data from.
          *
-         * Implementators: You should setup when a {@link GFlow.Source} is set
-         * and when is set to null, you should release any connection from {@link GFlow.Source}.
+         * User {@link Dock.connect} to change {@link GFlow.Source}.
          */
-        public abstract weak Source? source { get; set; }
-
-// FIXME: May avoid to rise error but a signal
-        public virtual void change_source (Source s) throws NodeError {
-            this.unset_source();
-            if (this.val.type() != s.val.type()) {
-                throw new NodeError.INCOMPATIBLE_SOURCETYPE(
-                    "Can't connect. Source has type %s while Sink has type %s".printf(
-                        s.val.type().name(), this.val.type().name()
-                    )
-                );
-            }
-            this.source = s;
-            if (((Source) this.source).is_connected_to (this)) // FIXME This is a Sink not a Source - Change is_connected_to () to use a Dock not a Source?
-                this.source.add_sink (this);
-            this.connected(s);
-        }
-
-// FIXME: May on invalidate() you should release the source
-// FIXME: Let this to implementators when source = null is called
-        public virtual void unset_source () {
-            if (((Sink) this.source).is_connected_to (this))
-                this.source.remove_sink (this);
-            Source s = this.source;
-            this.source = null;
-            this.invalidate ();
-            this.disconnected (s);
-        }
-
-        /**
-         * Checks if there is a source that supplies this sink with a value.
-         * If yes, it returns that value. If not, returns the default value of
-         * This Sink // FIXME May is not necesary to throw an error just return NULL
-         */
-        public virtual GLib.Value get_value() throws NodeError {
-            if (this.source != null && this.valid) {
-                return this.val;
-            } else {
-                throw new NodeError.NO_SOURCE("This sink has no source to drain data from");
-            }
-        }
-
-        public virtual void change_value (GLib.Value v) throws NodeError {
-            if (this.val.type() != v.type())
-                throw new NodeError.INCOMPATIBLE_VALUE (
-                    "Cannot feed a %s value into this %s Sink".printf(
-                        v.type().name(),this.val.type().name())
-                );
-            this.val = v;
-            // FIXME: This properly is read-only then may let implementators to define how "Change a Value"
-            //this.valid = true;
-            this.changed ();
-        }
+        public abstract weak Source? source { get; }
     }
 }

--- a/libgflow/gflow-source.vala
+++ b/libgflow/gflow-source.vala
@@ -25,56 +25,18 @@ namespace GFlow {
      * A Source could be used by multitude of Sinks as a source of data. // FIXME Is this correct?
      */
     public interface Source : Object, Dock {
+        public signal void updated ();
         /**
-        * FIXME This should be read-only
+        * FIXME This should be read-only (when you get it from here this could be modified by user)
         * FIXME May be the way to make sinks read-only is to return an owned copy of it to avoid writes on lists
          * Returns the sinks that this source is connected to
          */
         public abstract List<Sink> sinks { get; }
 
-        public virtual void set_value(GLib.Value v) throws NodeError {
-            if (this.val.type() != v.type())
-                throw new NodeError.INCOMPATIBLE_VALUE(
-                    "Cannot set a %s value to this %s Source".printf(
-                        v.type().name(),this.val.type().name())
-                );
-            this.val = v;
+        public virtual void disconnect_all () throws GLib.Error
+        {
             foreach (Sink s in this.sinks)
-                s.change_value(v);
-        }
-
-        public virtual void add_sink(Sink s) throws NodeError {
-            if (this.val.type() != s.val.type()) {
-                throw new NodeError.INCOMPATIBLE_SINKTYPE(
-                    "Can't connect. Sink has type %s while Source has type %s".printf(
-                        s.val.type().name(), this.val.type().name()
-                    )
-                );
-            }
-            if (this.sinks.index(s) == -1)
-                this.sinks.append(s);
-            if (!((Dock) s).is_connected_to(this))
-                s.source = this;
-            if (this.valid) {
-                s.change_value(this.val);
-            }
-        }
-/* FIXME This should not be set by user
-        public new void set_valid() {
-            this.valid = true;
-        }*/
-
-        public virtual void remove_sink(Sink s){
-            if (this.sinks.index(s) != -1)
-                this.sinks.remove(s);
-            if (s.is_connected_to(this))
-                s.unset_source();
-            this.disconnected(s);
-        }
-
-        public virtual void remove_sinks () {
-            foreach (Sink s in this.sinks)
-                this.remove_sink (s);
+                this.disconnect (s);
         }
     }
 }

--- a/test/gflow-sink-test.vala
+++ b/test/gflow-sink-test.vala
@@ -39,5 +39,25 @@ public class GFlowTest.SinkTest
       assert (s.source == null);
       assert (!s.is_connected ());
     });
+    Test.add_func ("/gflow/sink/source", 
+    () => {
+      Value initial = Value(typeof(int));
+      initial.set_int (1);
+      var s = new GFlow.SimpleSink (initial);
+      var src = new GFlow.SimpleSource (initial);
+      assert (s.initial != null);
+      assert (s.val != null);
+      assert (s.val.holds (typeof(int)));
+      assert (s.val.get_int () == 1);
+      assert (s.val.type () == typeof (int));
+      assert (!s.valid);
+      assert (!s.highlight);
+      assert (!s.active);
+      assert (s.node == null);
+      assert (s.source == null);
+      assert (!s.is_connected ());
+      //s.connect (src);
+      //assert (s.is_connected ());
+    });
   }
 }


### PR DESCRIPTION
This merge request, simplify most of GFlow interfaces at a point to try to make them as generic as possible.

I've added connect/disconnect method to Dock and implemented in SimpleSink and SimpleSource classes.

As you can see, Sink and Source can be connected to a given Dock, send a connected signal if successful and should send signals when changed and updated, then all Dock connected could react on it.

SimpleSink doesn't listen Source change it is connected to jet, but could just require to delete SimpleSource.change_value(). Now SimpleSource send a signal when it is updated then on connection SimpleSink should connect to this signal in order to react.

I'm focusing on Sink and Source implementations not Node, because they should be working and tested as required before to be used by Node/SimpleNode.

Now exists a bug on connect, SimpleSink can't connect to SimpleSource, but if the change above are Ok for you we can continue to fix it.