### PR TITLE
Node: update name layout immediately

### DIFF
--- a/libgtkflow/node.vala
+++ b/libgtkflow/node.vala
@@ -86,9 +86,12 @@ namespace GtkFlow {
             this.gnode.sink_added.connect((s)=>{this.register_dock(s);});
             this.gnode.source_removed.connect((s)=>{this.unregister_dock(s);});
             this.gnode.sink_removed.connect((s)=>{this.unregister_dock(s);});
+
+            this.node_renderer.update_name_layout(this.gnode.name);
             this.gnode.notify["name"].connect(()=>{
                 this.node_renderer.update_name_layout(this.gnode.name);
             });
+
             this.set_border_width(this.node_renderer.resize_handle_size);
 
             this.show_all();


### PR DESCRIPTION
So that if you pass a Node with a name already set, it works correctly.

This bug can be seen in `examples/different_types.py`